### PR TITLE
Switch to static menu action avoid getting menu timeout

### DIFF
--- a/dialog.html
+++ b/dialog.html
@@ -26,8 +26,8 @@
         <div>Thanks for using <a href="javascript:openUrl('https://aka.ms/open-in-excel')">VSTS Open in Excel</a>.</div>
         <div>This extension requires Microsoft Excel and one of the following clients to be installed:</div>
         <ul>
-            <li><span>Visual Studio 2017 RC (or later): <a href="javascript:openUrl('https://www.visualstudio.com/downloads/#visual-studio-enterprise-2017-rc')">Download</a></span></li>
-            <li><span>Team Foundation Server Office® Integration 2017 RC (or later): <a href="javascript:openUrl('https://www.visualstudio.com/downloads/#team-foundation-server-office-integration-2017-rc')">Download</a></span></li>
+            <li><span>Visual Studio 2017 RTW (or later): <a href="javascript:openUrl('https://www.visualstudio.com/downloads')">Download</a></span></li>
+            <li><span>Team Foundation Server Office® Integration 2017 RTW (or later): <a href="javascript:openUrl('https://www.visualstudio.com/downloads/#team-foundation-server-office-integration-2017')">Download</a></span></li>
         </ul>
         <div id="message">This dialog will close in <span id="countdown"></span> seconds... <a href="javascript:cancelAutoClose()">cancel</a></div>
     </div>

--- a/scripts/app.ts
+++ b/scripts/app.ts
@@ -75,76 +75,49 @@ export interface IActionContext {
 }
 
 export var openQueryAction = {
-    getMenuItems: (context: any) => {
-        if (!context || !context.query || !context.query.wiql || !isSupportedQueryId(context.query.id)) {
-            return null;
-        }
-        else {
-            return [<IContributedMenuItem>{
-                title: "Open in Excel",
-                text: "Open in Excel",
-                icon: "img/miniexcellogo.png",
-                action: (actionContext: IActionContext) => {
-                    if (actionContext && actionContext.query && actionContext.query.id) {
-                        const qid = actionContext.query.id;
-                        const context = VSS.getWebContext();
-                        const collectionUri = context.collection.uri;
-                        const projectName = context.project.name;
+    execute: (actionContext: IActionContext) => {
+        if (actionContext && actionContext.query && actionContext.query.id) {
+            const qid = actionContext.query.id;
+            const context = VSS.getWebContext();
+            const collectionUri = context.collection.uri;
+            const projectName = context.project.name;
 
-                        const url = generateUrl(SupportedActions.OpenQuery, collectionUri, projectName, qid);
-                        openUrl(url);
-                    }
-                }
-            }];
+            const url = generateUrl(SupportedActions.OpenQuery, collectionUri, projectName, qid);
+            openUrl(url);
         }
     }
 };
 
 export var openWorkItemsAction = {
-    getMenuItems: (context: any) => {
-        return [<IContributedMenuItem>{
-            title: "Open in Excel",
-            text: "Open in Excel",
-            icon: "img/miniexcellogo.png",
-            action: (actionContext: IActionContext) => {
-                const wids = actionContext.ids ||
-                    actionContext.workItemIds ||
-                    (actionContext.workItemId > 0 ? [actionContext.workItemId] : null) ||
-                    (actionContext.id > 0 ? [actionContext.id] : null);
-                const columns = actionContext.columns;
-                const context = VSS.getWebContext();
-                const collectionUri = context.collection.uri;
-                const projectName = context.project.name;
+    execute: (actionContext: IActionContext) => {
+        const wids = actionContext.ids ||
+            actionContext.workItemIds ||
+            (actionContext.workItemId > 0 ? [actionContext.workItemId] : null) ||
+            (actionContext.id > 0 ? [actionContext.id] : null);
+        const columns = actionContext.columns;
+        const context = VSS.getWebContext();
+        const collectionUri = context.collection.uri;
+        const projectName = context.project.name;
 
-                const url = generateUrl(SupportedActions.OpenItems, collectionUri, projectName, null, wids, columns);
-                openUrl(url);
-            }
-        }];
+        const url = generateUrl(SupportedActions.OpenItems, collectionUri, projectName, null, wids, columns);
+        openUrl(url);
     }
 };
 
 export var openQueryOnToolbarAction = {
-    getMenuItems: (context: any) => {
-        return [<IContributedMenuItem>{
-            title: "Open in Excel",
-            text: "Open in Excel",
-            icon: "img/miniexcellogo.png",
-            showText: true,
-            action: (actionContext: IActionContext) => {
-                if (actionContext && actionContext.query && actionContext.query.wiql && isSupportedQueryId(actionContext.query.id)) {
-                    const qid = actionContext.query.id;
-                    const context = VSS.getWebContext();
-                    const collectionUri = context.collection.uri;
-                    const projectName = context.project.name;
+    execute: (actionContext: IActionContext) => {
+        if (actionContext && actionContext.query && actionContext.query.wiql && isSupportedQueryId(actionContext.query.id)) {
+            const qid = actionContext.query.id;
+            const context = VSS.getWebContext();
+            const collectionUri = context.collection.uri;
+            const projectName = context.project.name;
 
-                    const url = generateUrl(SupportedActions.OpenQuery, collectionUri, projectName, qid);
-                    openUrl(url);
-                }
-                else {
-                    alert("Unable to perform operation. To use this extension, queries must be saved in My Queries or Shared Queries.");
-                }
-            }
-        }];
+            const url = generateUrl(SupportedActions.OpenQuery, collectionUri, projectName, qid);
+            openUrl(url);
+        }
+        else {
+            alert("Unable to perform operation. To use this extension, queries must be saved in My Queries or Shared Queries.");
+        }
     }
 };
 

--- a/vss-extension.json
+++ b/vss-extension.json
@@ -1,7 +1,7 @@
 {
     "manifestVersion": 1,
     "id": "vsts-open-work-items-in-excel",
-    "version": "0.1.57",
+    "version": "0.1.64",
     "name": "VSTS Open in Excel",
     "scopes": [
         "vso.work",
@@ -68,37 +68,43 @@
     "contributions": [
         {
             "id": "openQueryAction",
-            "type": "ms.vss-web.action-provider",
+            "type": "ms.vss-web.action",
             "description": "Open in Excel context menu on a query definition.",
             "targets": [
                 "ms.vss-work-web.work-item-query-menu"
             ],
             "properties": {
-                "group": "contributed",
+                "text": "Open in Excel",
+                "icon": "img/miniexcellogo.png",
+                "group": "actions",
                 "uri": "index.html"
             }
         },
         {
             "id": "openWorkItemsAction",
-            "type": "ms.vss-web.action-provider",
+            "type": "ms.vss-web.action",
             "description": "Open in Excel context menu on a work item.",
             "targets": [
                 "ms.vss-work-web.work-item-context-menu"
             ],
             "properties": {
-                "group": "contributed",
+                "text": "Open in Excel",
+                "icon": "img/miniexcellogo.png",
+                "group": "actions",
                 "uri": "index.html"
             }
         },
         {
             "id": "openQueryOnToolbarAction",
-            "type": "ms.vss-web.action-provider",
+            "type": "ms.vss-web.action",
             "description": "Open in Excel toolbar menu item on the query results.",
             "targets": [
                 "ms.vss-work-web.work-item-query-results-toolbar-menu"
             ],
             "properties": {
-                "group": "contributed",
+                "text": "Open in Excel",
+                "icon": "img/miniexcellogo.png",
+                "group": "actions",
                 "uri": "index.html"
             }
         },


### PR DESCRIPTION
It's unnecessary to use action provider as the menu item is static, this reduce the load time and avoid timeout when get menu item (especially multiple extensions load at same time) 